### PR TITLE
Update compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,11 +1,16 @@
 services:
   ecourse:
     container_name: ecourse
-    build: .
+    build:
+      context: .                     
+      dockerfile: Dockerfile
+      args:
+        VITE_PROD_PB_URL: "http://localhost:8090"   # <-- Change it for your IP
     restart: unless-stopped
     ports:
       - "8090:8090"
     volumes:
       - ecourse:/app/pb/pb_data
+
 volumes:
   ecourse:


### PR DESCRIPTION
fix(docker): allow setting VITE_PROD_PB_URL via build args to avoid CORS issues

Added support for overriding VITE_PROD_PB_URL using Docker build args. This fixes cross-origin request issues when running the frontend on a different host than 127.0.0.1.

Users can now set their actual server IP or domain via:
  build.args.VITE_PROD_PB_URL

This ensures the generated Svelte bundle includes the correct API URL at build time.